### PR TITLE
entropy: don't parse math

### DIFF
--- a/src/binwalk/modules/entropy.py
+++ b/src/binwalk/modules/entropy.py
@@ -285,6 +285,8 @@ class Entropy(Module):
         except ImportError as e:
             return
 
+        plt.rcParams["text.parse_math"] = False
+
         i = 0
         x = []
         y = []


### PR DESCRIPTION
if given things with dollars, matplotlib will try to parse latex and give exceptions.
Closes #11 